### PR TITLE
fix(task-28): correct demand estimation using price elasticity percentage

### DIFF
--- a/backend/src/main/java/com/felipeboos/gestao_produtos/service/EstrategiaPrecoService.java
+++ b/backend/src/main/java/com/felipeboos/gestao_produtos/service/EstrategiaPrecoService.java
@@ -120,6 +120,7 @@ public class EstrategiaPrecoService {
 
         Integer demandaEstimada = calcularDemandaEstimada(
                 produto.getDemandaBase(),
+                basePreco,
                 precoSugerido,
                 produto.getFatorElasticidade()
         );
@@ -198,18 +199,45 @@ public class EstrategiaPrecoService {
     }
 
     private Integer calcularDemandaEstimada(
-            Integer demandaBase,
-            BigDecimal precoSugerido,
-            BigDecimal fatorElasticidade
-    ) {
-        Integer quedaEstimadaVendas = precoSugerido.multiply(fatorElasticidade)
+                Integer demandaBase,
+                BigDecimal precoBase,
+                BigDecimal precoSugerido,
+                BigDecimal fatorElasticidade
+        ) {
+        if (demandaBase == null || demandaBase <= 0) {
+                return 0;
+        }
+
+        if (precoBase == null || precoBase.compareTo(BigDecimal.ZERO) <= 0) {
+                return demandaBase;
+        }
+
+        if (precoSugerido == null) {
+                return demandaBase;
+        }
+
+        if (fatorElasticidade == null) {
+                fatorElasticidade = BigDecimal.ZERO;
+        }
+
+        BigDecimal variacaoPercentualPreco = precoSugerido
+                .subtract(precoBase)
+                .divide(precoBase, SCALE_PERCENTUAL, RoundingMode.HALF_UP);
+
+        BigDecimal variacaoPercentualDemanda = variacaoPercentualPreco
+                .multiply(fatorElasticidade);
+
+        BigDecimal fatorDemanda = BigDecimal.ONE.subtract(variacaoPercentualDemanda);
+
+        BigDecimal demandaCalculada = BigDecimal.valueOf(demandaBase)
+                .multiply(fatorDemanda);
+
+        int demandaEstimada = demandaCalculada
                 .setScale(0, RoundingMode.HALF_UP)
                 .intValue();
 
-        Integer demandaEstimada = demandaBase - quedaEstimadaVendas;
-
         return Math.max(demandaEstimada, 0);
-    }
+        }
 
     private BigDecimal calcularImpostoTotal(
             BigDecimal impostoUnitario,
@@ -268,42 +296,51 @@ public class EstrategiaPrecoService {
         return BigDecimal.ZERO.setScale(SCALE_MONETARIO, RoundingMode.HALF_UP);
     }
 
-    private List<String> gerarAvisosEstrategia(EstrategiaPreco estrategiaPreco) {
+        private List<String> gerarAvisosEstrategia(EstrategiaPreco estrategiaPreco) {
         List<String> avisos = new ArrayList<>();
 
         if (estrategiaPreco == null || estrategiaPreco.getProduto() == null) {
-            return avisos;
+                return avisos;
         }
 
         if (estrategiaPreco.getDemandaEstimada() != null && estrategiaPreco.getDemandaEstimada() <= 0) {
-            BigDecimal fatorElasticidade = estrategiaPreco.getProduto().getFatorElasticidade();
-            String avisoTexto = "⚠️ Demanda estimada zerada: O fator de elasticidade do produto ("
-                    + String.format("%.2f", fatorElasticidade) + ") resultou em uma demanda estimada nula para a margem de lucro informada ("
-                    + String.format("%.2f", estrategiaPreco.getMargemLucro()) + "%). "
-                    + "Isso significa que o preço sugerido é tão alto que o produto não teria vendas estimadas. "
-                    + "Considere aumentar o fator de elasticidade do produto, aumentar a demanda base ou reduzir a margem de lucro.";
-            avisos.add(avisoTexto);
+                BigDecimal fatorElasticidade = estrategiaPreco.getProduto().getFatorElasticidade();
+
+                String avisoTexto = "⚠️ Demanda estimada zerada: A variação percentual entre o preço base e o preço sugerido, "
+                        + "combinada com o fator de elasticidade do produto ("
+                        + String.format("%.2f", fatorElasticidade != null ? fatorElasticidade : BigDecimal.ZERO)
+                        + "), resultou em uma demanda estimada nula para a margem de lucro informada ("
+                        + String.format("%.2f", estrategiaPreco.getMargemLucro())
+                        + "%). Considere reduzir a margem de lucro, revisar o preço base, revisar a demanda base "
+                        + "ou ajustar o fator de elasticidade do produto.";
+
+                avisos.add(avisoTexto);
         }
 
         if (estrategiaPreco.getLucroTotalEstimado() != null
                 && estrategiaPreco.getLucroTotalEstimado().compareTo(BigDecimal.ZERO) <= 0) {
-            avisos.add("⚠️ Lucro total zerado: A estratégia resultou em lucro total estimado igual a zero. "
-                    + "Não há viabilidade econômica nesta configuração.");
+                avisos.add("⚠️ Lucro total zerado: A estratégia resultou em lucro total estimado igual a zero. "
+                        + "Não há viabilidade econômica nesta configuração.");
         }
 
         Integer demandaBase = estrategiaPreco.getProduto().getDemandaBase();
+
         if (demandaBase != null
                 && demandaBase > 0
                 && estrategiaPreco.getDemandaEstimada() != null
                 && estrategiaPreco.getDemandaEstimada() < demandaBase * 0.1) {
-            double percentualDemanda = (estrategiaPreco.getDemandaEstimada().doubleValue()
-                    / demandaBase.doubleValue()) * 100;
-            String avisoTexto = "ℹ️ Demanda crítica: A demanda estimada ("
-                    + String.format("%.1f", percentualDemanda) + "% da demanda base) é muito baixa. "
-                    + "Revise a margem de lucro ou o fator de elasticidade do produto.";
-            avisos.add(avisoTexto);
+
+                double percentualDemanda = (estrategiaPreco.getDemandaEstimada().doubleValue()
+                        / demandaBase.doubleValue()) * 100;
+
+                String avisoTexto = "ℹ️ Demanda crítica: A demanda estimada ("
+                        + String.format("%.1f", percentualDemanda)
+                        + "% da demanda base) é muito baixa. "
+                        + "Revise a margem de lucro, o preço base ou o fator de elasticidade do produto.";
+
+                avisos.add(avisoTexto);
         }
 
         return avisos;
-    }
+        }
 }

--- a/backend/src/test/java/com/felipeboos/gestao_produtos/service/EstrategiaPrecoServiceTest.java
+++ b/backend/src/test/java/com/felipeboos/gestao_produtos/service/EstrategiaPrecoServiceTest.java
@@ -370,4 +370,165 @@ public class EstrategiaPrecoServiceTest {
         verify(repository, times(1)).existsById(1L);
         verify(repository, never()).deleteById(anyLong());
     }
+
+    @Test
+    @DisplayName("T14 - Deve manter demanda base quando preco sugerido for igual ao preco base")
+    void t14_deveManterDemandaBaseQuandoPrecoSugeridoForIgualAoPrecoBase() {
+        produto = Produto.builder()
+                .id(1L)
+                .nome("Produto teste")
+                .categoria(categoria)
+                .precoCusto(BigDecimal.valueOf(100.00))
+                .precoCustoEmReais(BigDecimal.valueOf(100.00))
+                .custoFinalAquisicao(BigDecimal.valueOf(100.00))
+                .demandaBase(100)
+                .fatorElasticidade(BigDecimal.valueOf(1.5))
+                .build();
+
+        requestDTO.setMargemLucro(BigDecimal.ZERO);
+        requestDTO.setPercentualImposto(BigDecimal.ZERO);
+
+        when(produtoRepository.findById(1L)).thenReturn(Optional.of(produto));
+
+        EstrategiaPrecoResponseDTO response = service.simularPreco(requestDTO);
+
+        assertEquals(0, response.getPrecoSugerido().compareTo(BigDecimal.valueOf(100.00)));
+        assertEquals(100, response.getDemandaEstimada());
+
+        verify(produtoRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("T15 - Deve reduzir demanda quando preco sugerido for maior que preco base")
+    void t15_deveReduzirDemandaQuandoPrecoSugeridoForMaiorQuePrecoBase() {
+        produto = Produto.builder()
+                .id(1L)
+                .nome("Produto teste")
+                .categoria(categoria)
+                .precoCusto(BigDecimal.valueOf(100.00))
+                .precoCustoEmReais(BigDecimal.valueOf(100.00))
+                .custoFinalAquisicao(BigDecimal.valueOf(100.00))
+                .demandaBase(1000)
+                .fatorElasticidade(BigDecimal.valueOf(1.5))
+                .build();
+
+        requestDTO.setMargemLucro(BigDecimal.valueOf(20));
+        requestDTO.setPercentualImposto(BigDecimal.ZERO);
+
+        when(produtoRepository.findById(1L)).thenReturn(Optional.of(produto));
+
+        EstrategiaPrecoResponseDTO response = service.simularPreco(requestDTO);
+
+        assertEquals(0, response.getPrecoSugerido().compareTo(BigDecimal.valueOf(120.00)));
+        assertEquals(700, response.getDemandaEstimada());
+
+        verify(produtoRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("T16 - Deve aumentar demanda quando preco sugerido for menor que preco base")
+    void t16_deveAumentarDemandaQuandoPrecoSugeridoForMenorQuePrecoBase() {
+        produto = Produto.builder()
+                .id(1L)
+                .nome("Produto teste")
+                .categoria(categoria)
+                .precoCusto(BigDecimal.valueOf(100.00))
+                .precoCustoEmReais(BigDecimal.valueOf(100.00))
+                .custoFinalAquisicao(BigDecimal.valueOf(100.00))
+                .demandaBase(1000)
+                .fatorElasticidade(BigDecimal.valueOf(1.5))
+                .build();
+
+        requestDTO.setMargemLucro(BigDecimal.valueOf(-20));
+        requestDTO.setPercentualImposto(BigDecimal.ZERO);
+
+        when(produtoRepository.findById(1L)).thenReturn(Optional.of(produto));
+
+        EstrategiaPrecoResponseDTO response = service.simularPreco(requestDTO);
+
+        assertEquals(0, response.getPrecoSugerido().compareTo(BigDecimal.valueOf(80.00)));
+        assertEquals(1300, response.getDemandaEstimada());
+
+        verify(produtoRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("T17 - Deve impedir demanda negativa quando elasticidade for alta")
+    void t17_deveImpedirDemandaNegativaQuandoElasticidadeForAlta() {
+        produto = Produto.builder()
+                .id(1L)
+                .nome("Produto teste")
+                .categoria(categoria)
+                .precoCusto(BigDecimal.valueOf(100.00))
+                .precoCustoEmReais(BigDecimal.valueOf(100.00))
+                .custoFinalAquisicao(BigDecimal.valueOf(100.00))
+                .demandaBase(1000)
+                .fatorElasticidade(BigDecimal.valueOf(2.0))
+                .build();
+
+        requestDTO.setMargemLucro(BigDecimal.valueOf(100));
+        requestDTO.setPercentualImposto(BigDecimal.ZERO);
+
+        when(produtoRepository.findById(1L)).thenReturn(Optional.of(produto));
+
+        EstrategiaPrecoResponseDTO response = service.simularPreco(requestDTO);
+
+        assertEquals(0, response.getPrecoSugerido().compareTo(BigDecimal.valueOf(200.00)));
+        assertEquals(0, response.getDemandaEstimada());
+
+        verify(produtoRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("T18 - Deve manter demanda base quando preco base for zero")
+    void t18_deveManterDemandaBaseQuandoPrecoBaseForZero() {
+        produto = Produto.builder()
+                .id(1L)
+                .nome("Produto teste")
+                .categoria(categoria)
+                .precoCusto(BigDecimal.ZERO)
+                .precoCustoEmReais(BigDecimal.ZERO)
+                .custoFinalAquisicao(BigDecimal.ZERO)
+                .demandaBase(100)
+                .fatorElasticidade(BigDecimal.valueOf(1.5))
+                .build();
+
+        requestDTO.setMargemLucro(BigDecimal.valueOf(20));
+        requestDTO.setPercentualImposto(BigDecimal.ZERO);
+
+        when(produtoRepository.findById(1L)).thenReturn(Optional.of(produto));
+
+        EstrategiaPrecoResponseDTO response = service.simularPreco(requestDTO);
+
+        assertEquals(100, response.getDemandaEstimada());
+
+        verify(produtoRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("T19 - Deve manter demanda base quando fator de elasticidade for nulo")
+    void t19_deveManterDemandaBaseQuandoFatorElasticidadeForNulo() {
+        produto = Produto.builder()
+                .id(1L)
+                .nome("Produto teste")
+                .categoria(categoria)
+                .precoCusto(BigDecimal.valueOf(100.00))
+                .precoCustoEmReais(BigDecimal.valueOf(100.00))
+                .custoFinalAquisicao(BigDecimal.valueOf(100.00))
+                .demandaBase(1000)
+                .fatorElasticidade(null)
+                .build();
+
+        requestDTO.setMargemLucro(BigDecimal.valueOf(20));
+        requestDTO.setPercentualImposto(BigDecimal.ZERO);
+
+        when(produtoRepository.findById(1L)).thenReturn(Optional.of(produto));
+
+        EstrategiaPrecoResponseDTO response = service.simularPreco(requestDTO);
+
+        assertEquals(0, response.getPrecoSugerido().compareTo(BigDecimal.valueOf(120.00)));
+        assertEquals(1000, response.getDemandaEstimada());
+
+        verify(produtoRepository, times(1)).findById(1L);
+    }
 }

--- a/backend/src/test/java/com/felipeboos/gestao_produtos/service/EstrategiaPrecoServiceTest.java
+++ b/backend/src/test/java/com/felipeboos/gestao_produtos/service/EstrategiaPrecoServiceTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,8 +47,8 @@ public class EstrategiaPrecoServiceTest {
 
     private final BigDecimal precoSugeridoEsperado = BigDecimal.valueOf(712.80);
     private final BigDecimal lucroUnitarioEsperado = BigDecimal.valueOf(108.00);
-    private final int demandaEstimadaEsperada = 64;
-    private final BigDecimal lucroTotalEsperado = BigDecimal.valueOf(6912.00);
+    private final int demandaEstimadaEsperada = 98;
+    private final BigDecimal lucroTotalEsperado = BigDecimal.valueOf(10584.00);
 
     @BeforeEach
     void setup() {
@@ -316,7 +318,7 @@ public class EstrategiaPrecoServiceTest {
         assertEquals("Produto teste", response.get(0).getProdutoNome());
         assertEquals("Eletrônicos", response.get(0).getCategoriaNome());
         assertEquals(0, response.get(0).getPrecoUnidade().compareTo(BigDecimal.valueOf(540.00)));
-        assertEquals(0, response.get(0).getLucroTotalEstimado().compareTo(BigDecimal.valueOf(6912.00)));
+        assertEquals(0, response.get(0).getLucroTotalEstimado().compareTo(BigDecimal.valueOf(10584.00)));
 
         assertEquals(2L, response.get(1).getId());
         assertEquals(1L, response.get(1).getProdutoId());


### PR DESCRIPTION
## Objective

Fix demand estimation logic to use percentage-based price variation instead of absolute price values.

---

## What was changed

- Refactored demand calculation to use:
  - (suggestedPrice - basePrice) / basePrice
- Introduced price elasticity behavior based on percentage variation
- Prevented unrealistic demand collapse caused by absolute price multiplication
- Ensured demand is never negative

---

## Tests

### Unit tests
- Added tests for:
  - Equal price scenario (no demand change)
  - Price increase (demand decreases)
  - Price decrease (demand increases)
  - High elasticity (demand capped at zero)
  - Edge cases (null elasticity, zero base price)

### Manual validation (Postman)
- Equal price → demand unchanged ✔
- Price increase → demand decreases proportionally ✔
- High elasticity → demand reaches zero without breaking ✔
- Profit and tax calculations remain consistent ✔

---

## Impact

- Improves economic realism of price simulation
- Prevents incorrect zero-demand scenarios
- Keeps backward compatibility with existing API

---

## Notes

- Negative margin scenarios are currently blocked by validation
- Demand increase scenarios were validated via unit tests

Closes #28